### PR TITLE
Update ClickHouse version to 24.3 and add cluster outputs

### DIFF
--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -66,7 +66,7 @@ module "clickhouse" {
   clickhouse_disk_type_id       = "network-ssd"
   clickhouse_resource_preset_id = "s3-c2-m8"
   environment                   = "PRODUCTION"
-  clickhouse_version            = "23.8"
+  clickhouse_version            = "24.3"
   description                   = "ClickHouse cluster description"
   folder_id                     = data.yandex_client_config.client.folder_id
 

--- a/examples/simple/outputs.tf
+++ b/examples/simple/outputs.tf
@@ -32,4 +32,5 @@ output "databases" {
 output "connection" {
   description = "The connection in which the ClickHouse cluster is deployed."
   value       = module.clickhouse.connection
+  sensitive   = true
 }

--- a/examples/simple/outputs.tf
+++ b/examples/simple/outputs.tf
@@ -9,17 +9,17 @@ output "cluster_name" {
 }
 
 output "cluster_host_zones_list" {
-  description = "The cluster_host_zones_list of the ClickHouse cluster."
+  description = "The list of zones where the ClickHouse cluster hosts are located."
   value       = module.clickhouse.cluster_host_zones_list
 }
 
 output "cluster_fqdns_list" {
-  description = "The fully qualified domain name (FQDN) of the ClickHouse cluster."
+  description = "The list of fully qualified domain names (FQDN) for the ClickHouse cluster nodes."
   value       = module.clickhouse.cluster_fqdns_list
 }
 
 output "cluster_users" {
-  description = "The list of users created in the ClickHouse cluster."
+  description = "The list of users created in the ClickHouse cluster, including their passwords."
   value       = module.clickhouse.cluster_users
   sensitive   = true
 }

--- a/examples/simple/outputs.tf
+++ b/examples/simple/outputs.tf
@@ -1,0 +1,35 @@
+output "cluster_id" {
+  description = "The ID of the ClickHouse cluster."
+  value       = module.clickhouse.cluster_id
+}
+
+output "cluster_name" {
+  description = "The name of the ClickHouse cluster."
+  value       = module.clickhouse.cluster_name
+}
+
+output "cluster_host_zones_list" {
+  description = "The cluster_host_zones_list of the ClickHouse cluster."
+  value       = module.clickhouse.cluster_host_zones_list
+}
+
+output "cluster_fqdns_list" {
+  description = "The fully qualified domain name (FQDN) of the ClickHouse cluster."
+  value       = module.clickhouse.cluster_fqdns_list
+}
+
+output "cluster_users" {
+  description = "The list of users created in the ClickHouse cluster."
+  value       = module.clickhouse.cluster_users
+  sensitive   = true
+}
+
+output "databases" {
+  description = "The list of databases created in the ClickHouse cluster."
+  value       = module.clickhouse.databases
+}
+
+output "connection" {
+  description = "The connection in which the ClickHouse cluster is deployed."
+  value       = module.clickhouse.connection
+}

--- a/examples/sql-user-management/outputs.tf
+++ b/examples/sql-user-management/outputs.tf
@@ -9,17 +9,17 @@ output "cluster_name" {
 }
 
 output "cluster_host_zones_list" {
-  description = "The cluster_host_zones_list of the ClickHouse cluster."
+  description = "The list of zones where the ClickHouse cluster hosts are located."
   value       = module.clickhouse.cluster_host_zones_list
 }
 
 output "cluster_fqdns_list" {
-  description = "The fully qualified domain name (FQDN) of the ClickHouse cluster."
+  description = "The list of fully qualified domain names (FQDN) for the ClickHouse cluster nodes."
   value       = module.clickhouse.cluster_fqdns_list
 }
 
 output "cluster_users" {
-  description = "The list of users created in the ClickHouse cluster."
+  description = "The list of users created in the ClickHouse cluster, including their passwords."
   value       = module.clickhouse.cluster_users
   sensitive   = true
 }

--- a/examples/sql-user-management/outputs.tf
+++ b/examples/sql-user-management/outputs.tf
@@ -1,0 +1,35 @@
+output "cluster_id" {
+  description = "The ID of the ClickHouse cluster."
+  value       = module.clickhouse.cluster_id
+}
+
+output "cluster_name" {
+  description = "The name of the ClickHouse cluster."
+  value       = module.clickhouse.cluster_name
+}
+
+output "cluster_host_zones_list" {
+  description = "The cluster_host_zones_list of the ClickHouse cluster."
+  value       = module.clickhouse.cluster_host_zones_list
+}
+
+output "cluster_fqdns_list" {
+  description = "The fully qualified domain name (FQDN) of the ClickHouse cluster."
+  value       = module.clickhouse.cluster_fqdns_list
+}
+
+output "cluster_users" {
+  description = "The list of users created in the ClickHouse cluster."
+  value       = module.clickhouse.cluster_users
+  sensitive   = true
+}
+
+output "databases" {
+  description = "The list of databases created in the ClickHouse cluster."
+  value       = module.clickhouse.databases
+}
+
+output "connection" {
+  description = "The connection in which the ClickHouse cluster is deployed."
+  value       = module.clickhouse.connection
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -59,5 +59,6 @@ output "connection" {
                   --ask-password
   EOF
 
-  value = "clickhouse-client --host c-${yandex_mdb_clickhouse_cluster.this.id}.rw.mdb.yandexcloud.net --secure --port 9440 --ask-password"
+  value       = "clickhouse-client --host ${tolist(yandex_mdb_clickhouse_cluster.this.host)[0].fqdn} --secure --user ${tolist(yandex_mdb_clickhouse_cluster.this.user)[0].name} --database ${var.databases[0].name} --port 9440 --ask-password"
+  sensitive   = true
 }


### PR DESCRIPTION
#### Summary
This pull request updates the ClickHouse version from 23.8 to 24.3 in the example configuration and adds new outputs to provide detailed information about the ClickHouse cluster.

#### Changes
- **Version Update**: The ClickHouse version has been updated from 23.8 to 24.3 in the `examples/simple/main.tf` file.
- **Output Additions**: New outputs have been added to the `examples/simple/outputs.tf` file to provide the following information:
  - **Cluster ID**: The unique identifier of the ClickHouse cluster.
  - **Cluster Name**: The name of the ClickHouse cluster.
  - **Host Zones List**: A list of zones where the cluster hosts are located.
  - **FQDNs List**: A list of fully qualified domain names (FQDN) for the cluster nodes.
  - **Users List**: A list of users created in the cluster, including their passwords (marked as sensitive).
  - **Databases List**: A list of databases created in the cluster.
  - **Connection Instructions**: Instructions on how to connect to the ClickHouse cluster, including certificate installation and configuration upload.

#### Rationale
These changes enhance the example by providing more visibility into the deployed ClickHouse cluster and its configuration. This will help users understand and interact with the cluster more effectively.


#### Additional Notes
- The connection instructions include steps for installing the necessary certificate and uploading the configuration file, which are essential for securely connecting to the ClickHouse cluster.

---

Feel free to adjust the text as needed to better fit your project's standards and conventions.